### PR TITLE
Feature/#4 location manager

### DIFF
--- a/NEMO-fourcut-map-ios/LocationManager.swift
+++ b/NEMO-fourcut-map-ios/LocationManager.swift
@@ -56,6 +56,8 @@ final class LocationManager: NSObject {
     }
 }
 
+// MARK: - CLLocationManagerDelegate
+
 extension LocationManager: CLLocationManagerDelegate {
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         checkUserLocationServiceAuthorization()

--- a/NEMO-fourcut-map-ios/LocationManager.swift
+++ b/NEMO-fourcut-map-ios/LocationManager.swift
@@ -1,0 +1,79 @@
+//
+//  LocationManager.swift
+//  NEMO-fourcut-map-ios
+//
+//  Created by sanghyo on 2022/09/26.
+//
+
+import CoreLocation
+
+final class LocationManager: NSObject {
+    static let shared = LocationManager()
+    private let manager = CLLocationManager()
+    private var currentLocation: CLLocation?
+    var locationAuthorizationStatus: CLAuthorizationStatus {
+        get {
+            if #available(iOS 14.0, *) {
+                return manager.authorizationStatus
+            }  else {
+                CLLocationManager.authorizationStatus()
+            }
+        }
+    }
+    var locateCurrentLocation: (CLLocation) -> Void = { _ in }
+    var handleToAuthorizedState: () -> Void = { }
+    
+    override init() {
+        super.init()
+        manager.delegate = self
+        settingLocationManager()
+    }
+    
+    func getCurrentLocation() -> CLLocation? { return currentLocation }
+    
+    private func settingLocationManager() {
+        if CLLocationManager.locationServicesEnabled() {
+            if locationAuthorizationStatus == .notDetermined {
+                manager.requestWhenInUseAuthorization()
+            } else if locationAuthorizationStatus == .authorizedAlways || locationAuthorizationStatus == .authorizedWhenInUse {
+                manager.startUpdatingLocation()
+            }
+        }
+    }
+    
+    private func checkUserLocationServiceAuthorization() {
+        switch locationAuthorizationStatus {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .restricted, .denied:
+            handleToAuthorizedState()
+            print("restricted")
+        case .authorizedWhenInUse:
+            manager.startUpdatingLocation()
+        default:
+            print("default")
+        }
+    }
+}
+
+extension LocationManager: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        checkUserLocationServiceAuthorization()
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        checkUserLocationServiceAuthorization()
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        manager.stopUpdatingLocation()
+        guard let lastLocation = locations.last else { return }
+        locateCurrentLocation(lastLocation)
+        currentLocation = lastLocation
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("fail")
+        // TODO: fail에 대한 처리 필요
+    }
+}

--- a/NEMO-fourcut-map-ios/Screens/Home/Controllers/HomeViewController.swift
+++ b/NEMO-fourcut-map-ios/Screens/Home/Controllers/HomeViewController.swift
@@ -16,12 +16,14 @@ final class HomeViewController: UIViewController {
         static let minimumInterItem: CGFloat = 10
     }
     
+    private let locationManager = LocationManager.shared 
     private var storeList: [Int] = [1, 2, 3, 4, 5]
     private var currentPageIndex: CGFloat = 0
 
-    private let mapView: UIView = {
+    private let mapView: NMFMapView = {
         let mapView = NMFMapView()
         mapView.zoomLevel = 15
+        mapView.positionMode = .compass
         return mapView
     }()
     private lazy var addressButton: UIButton = {
@@ -86,8 +88,18 @@ final class HomeViewController: UIViewController {
         configureDelegate()
     }
     
-    // MARK: - configure
+    // MARK: - closure
     
+    private lazy var locateUserLocation: (CLLocation) -> Void = { [weak self] location in
+        let camPosition = NMGLatLng(lat: location.coordinate.latitude, lng: location.coordinate.longitude)
+        let cameraUpdate = NMFCameraUpdate(scrollTo: camPosition)
+        cameraUpdate.animation = .easeIn
+        cameraUpdate.animationDuration = 0.5
+        self?.mapView.moveCamera(cameraUpdate)
+    }
+    
+    // MARK: - configure
+        
     private func configureDelegate() {
         storeCollectionView.dataSource = self
         storeCollectionView.delegate = self
@@ -133,8 +145,8 @@ final class HomeViewController: UIViewController {
         }
     }
 }
-
 // MARK: - UICollectionViewDataSource
+    
 extension HomeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         let count = storeList.isEmpty ? 1 : storeList.count


### PR DESCRIPTION
# 이슈 번호
🔒 Close #4 

## 구현 / 변경 사항 이유
- 현재 위치를 표시하기 위해서 CoreLocation의 CLLocationManager 사용
<img width="250" src="https://user-images.githubusercontent.com/26588989/192287693-edfa438a-3687-4020-a9ea-0a365b399710.jpeg">

### 현재 위치를 받아오는 원리 코드 분석
권한에 따른 처리 코드
```swift
var locationAuthorizationStatus: CLAuthorizationStatus {
        get {
            if #available(iOS 14.0, *) {
                return manager.authorizationStatus
            }  else {
                CLLocationManager.authorizationStatus()
            }
        }
    }

private func settingLocationManager() {
        // device 자체에서 위치 정보를 얻어올 것을 허용했는지 판단. Settings > Privacy에서 확인 가능
        if CLLocationManager.locationServicesEnabled() {
        // 앱 내에서 
            if locationAuthorizationStatus == .notDetermined {
                manager.requestWhenInUseAuthorization()
            } else if locationAuthorizationStatus == .authorizedAlways || locationAuthorizationStatus == .authorizedWhenInUse {
                manager.startUpdatingLocation()
            }
        }
    }
```
CLLocationMangerDelegate 코드
```swift
extension LocationManager: CLLocationManagerDelegate {
    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
        checkUserLocationServiceAuthorization()
    }
    
    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
        checkUserLocationServiceAuthorization()
    }
    
    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
        manager.stopUpdatingLocation()
        guard let lastLocation = locations.last else { return }
        locateCurrentLocation(lastLocation)
        currentLocation = lastLocation
    }
    
    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
        print("fail")
        // TODO: fail에 대한 처리 필요
    }
}
```
manager.stopUpdatingLocation() 부분에서 해당 부분을 호출하지 않으면 계속해서 location을 업데이트 하기 때문에 필요하지 않은경우 stop을 해줘야한다고 했고 많은 예시 코드에서 사용했다.
이 부분에서 stop을 하게 되면 유저의 움직임을 받아오지 못하는데 괜찮나?하는 의문이 들었다.
위치를 이동할 때 stop이 실행되어 지도에 반영되지 않을 것 이라는 생각이 들었는데, 이동하는게 보였다
stop하는 코드에 대한 이해가 부족해보인다

### Location Manger를 따로 만들고 singleton으로 사용해야하는 이유
여러개의 글을 찾아봤지만 명확한 이유를 찾지는 못했다. CLLocationManger가 무거운 객체이니 한번 생성하고 사용하라...? 와 같은 글을 얼핏 본 적이 있었는데 조금 더 와닿는 글을 찾고 싶었다.
찾아보다가 외국 글들에서 찾은 근거는 아래와 같다

1. 단일 페이지에서 location manager를 사용하는 경우 따로 class로 만들고 singleton으로 만들 이유는 없다
2. 앱 내부에서 여러개의 페이지에서 location manager를 사용하고 정보를 얻어오는 경우, 하나의 manager로 상태를 관리하는 것이 좋기 때문에 singleton 사용이 적절하다

나의 경우 2번에 해당했기 때문에 singleton으로 사용하기로 했다

## 리뷰 포인트
- CLLocationManagerDelegate의 didFailWithError에서 fail이 어떤 상황에서 발생하는지, 어떻게 처리해줘야하는지 공부하고 핸들링을 해줘야한다
- stopUpdatingLocation은 어떤 작용을 하는지?

## References
https://fluffy.es/current-location/
https://co-dong.tistory.com/73
https://www.appsloveworld.com/swift/100/107/should-i-use-a-singleton-location-manager-in-swift