### PR TITLE
[Feature] #31 개인 후기 및 리뷰 요약 UI

### DIFF
--- a/NEMO-fourcut-map-ios/Extension/SwiftUI+UIKit.swift
+++ b/NEMO-fourcut-map-ios/Extension/SwiftUI+UIKit.swift
@@ -1,0 +1,53 @@
+//
+//  SwiftUI+UIKit.swift
+//  NEMO-fourcut-map-ios
+//
+//  Created by sanghyo on 2023/01/12.
+//
+
+#if DEBUG
+import UIKit
+import SwiftUI
+
+extension UIViewController {
+    public struct UIViewControllerPreview<ViewController: UIViewController>: UIViewControllerRepresentable {
+        public let viewController: ViewController
+
+        public init(_ builder: @autoclosure () -> ViewController) {
+            viewController = builder()
+        }
+
+        // MARK: - UIViewControllerRepresentable
+        public func makeUIViewController(context: Context) -> ViewController {
+            viewController
+        }
+
+        public func updateUIViewController(_ uiViewController: ViewController, context: UIViewControllerRepresentableContext<UIViewControllerPreview<ViewController>>) {
+
+        }
+    }
+
+    func toPreview() -> some View {
+        UIViewControllerPreview(self)
+    }
+}
+
+extension UIView {
+    public struct UIViewPreview<View: UIView>: UIViewRepresentable {
+            public let view: View
+            public init(_ builder: @autoclosure () -> View) {
+                view = builder()
+            }
+            // MARK: - UIViewRepresentable
+            public func makeUIView(context: Context) -> UIView {
+                return view
+            }
+            public func updateUIView(_ view: UIView, context: Context) {
+            }
+        }
+
+    func toPreview() -> some View {
+        UIViewPreview(self)
+    }
+}
+#endif

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Controllers/DetailStoreViewController.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Controllers/DetailStoreViewController.swift
@@ -137,6 +137,66 @@ final class DetailStoreViewController: UIViewController {
         return button
     }()
     
+    private let reviewLabel: UILabel = {
+        let label = UILabel()
+        label.text = "후기"
+        label.textColor = .customBlack
+        label.font = UIFont.contentsTitle
+        return label
+    }()
+    
+    private let reviewSummaryContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 10
+        view.layer.borderColor = UIColor.customGray?.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+
+    private let reviewSummaryLabel: UILabel = {
+        let label = UILabel()
+        label.text = "리뷰 요약"
+        label.textColor = .customBlack
+        label.font = UIFont.contentsAccent
+        return label
+    }()
+    
+    private let reviewSummaryStar: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = ImageLiterals.filledStar
+        imageView.tintColor = .brandPink
+        return imageView
+    }()
+    
+    private let reviewSummaryRating: UILabel = {
+        let label = UILabel()
+        label.text = "5.0점"
+        label.textColor = .customBlack
+        label.font = UIFont.contentsAccent
+        return label
+    }()
+    
+    private lazy var reviewSummaryRatingStack: UIStackView = {
+        let stackView = UIStackView()
+        return stackView
+    }()
+    
+    private let reviewFirst: ReviewProgressStack = .init("조명", feelingLabel: "만족스러워요", textColor: .customBlack, textFont: .miniSemibold, tintColor: .brandPink, trackColor: .darkGray)
+    
+    private let reviewSecond: ReviewProgressStack = .init("보정", feelingLabel: "만족스러워요", textColor: .customBlack, textFont: .miniSemibold, tintColor: .brandPink, trackColor: .darkGray)
+    
+    private let reviewThird: ReviewProgressStack = .init("청결", feelingLabel: "깔끔,쾌적해요", textColor: .customBlack, textFont: .miniSemibold, tintColor: .brandPink, trackColor: .darkGray)
+    
+    private lazy var reviewSummaryStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [reviewFirst, reviewSecond, reviewThird])
+        stack.axis = .vertical
+        stack.distribution = .fillEqually
+        stack.spacing = 10
+        stack.alignment = .fill
+        return stack
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
@@ -176,22 +236,26 @@ final class DetailStoreViewController: UIViewController {
             retakeInfoLabel,
             retakeInfoCard,
             infoEditButton,
-            reviewWriteButton
+            reviewWriteButton,
+            reviewLabel,
+            reviewSummaryContainer
         )
         qrInfoCard.addSubviews(qrInfo)
         retakeInfoCard.addSubviews(retakeInfo)
+        reviewSummaryContainer.addSubviews(reviewSummaryLabel,
+                                            reviewSummaryStack)
     }
     
     private func configureConstraints() {
         
         detailStoreScrollView.snp.makeConstraints {
-            $0.leading.trailing.top.bottom.equalTo(view)
+            $0.edges.equalToSuperview()
         }
         
         contentView.snp.makeConstraints {
-            $0.leading.trailing.top.bottom.equalToSuperview()
-            $0.width.equalToSuperview()
-            $0.height.greaterThanOrEqualToSuperview()
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(detailStoreScrollView.snp.width)
+            $0.height.greaterThanOrEqualTo(detailStoreScrollView.snp.height).priority(.low)
         }
         
         mapView.snp.makeConstraints {
@@ -244,7 +308,7 @@ final class DetailStoreViewController: UIViewController {
         }
         
         retakeInfoLabel.snp.makeConstraints {
-            $0.leading.equalTo(storeInfoLabel)
+            $0.leading.equalTo(storeInfoLabel.snp.leading)
             $0.top.equalTo(qrInfoCard.snp.bottom).offset(30)
         }
         
@@ -261,6 +325,27 @@ final class DetailStoreViewController: UIViewController {
         infoEditButton.snp.makeConstraints {
             $0.trailing.equalTo(storeDetailInfoCard.snp.trailing)
             $0.centerY.equalTo(storeInfoLabel)
+        }
+        
+        reviewLabel.snp.makeConstraints {
+            $0.leading.equalTo(storeInfoLabel.snp.leading)
+            $0.top.equalTo(retakeInfoCard.snp.bottom).offset(40)
+        }
+        
+        reviewSummaryContainer.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(Size.sidePadding)
+            $0.top.equalTo(reviewLabel.snp.bottom).offset(16)
+        }
+        
+        reviewSummaryLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.leading.equalToSuperview().inset(10)
+        }
+        
+        reviewSummaryStack.snp.makeConstraints {
+            $0.top.equalTo(reviewSummaryLabel.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().offset(-60)
         }
     }
 }

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Controllers/DetailStoreViewController.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Controllers/DetailStoreViewController.swift
@@ -251,11 +251,10 @@ final class DetailStoreViewController: UIViewController {
         detailStoreScrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-        
+
         contentView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            $0.width.equalTo(detailStoreScrollView.snp.width)
-            $0.height.greaterThanOrEqualTo(detailStoreScrollView.snp.height).priority(.low)
+            $0.centerX.top.bottom.equalToSuperview()
+            $0.width.equalToSuperview()
         }
         
         mapView.snp.makeConstraints {
@@ -335,6 +334,8 @@ final class DetailStoreViewController: UIViewController {
         reviewSummaryContainer.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(Size.sidePadding)
             $0.top.equalTo(reviewLabel.snp.bottom).offset(16)
+            // TODO: 추가 공부
+            $0.bottom.equalToSuperview() // 이 부분을 해주지 않아서 scroll이 영역을 잡지 못했음. 추가 공부 필요
         }
         
         reviewSummaryLabel.snp.makeConstraints {

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Controllers/DetailStoreViewController.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Controllers/DetailStoreViewController.swift
@@ -339,14 +339,14 @@ final class DetailStoreViewController: UIViewController {
         }
         
         reviewSummaryLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(16)
+            $0.top.equalToSuperview().offset(27)
             $0.leading.equalToSuperview().inset(10)
         }
         
         reviewSummaryStack.snp.makeConstraints {
             $0.top.equalTo(reviewSummaryLabel.snp.bottom).offset(24)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().offset(-60)
+            $0.bottom.equalToSuperview().offset(-40)
         }
     }
 }

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/PaddingLabel.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/PaddingLabel.swift
@@ -1,0 +1,29 @@
+//
+//  PaddingLabel.swift
+//  NEMO-fourcut-map-ios
+//
+//  Created by sanghyo on 2023/01/12.
+//
+
+import UIKit
+
+final class PaddingLabel: UILabel {
+    private var inset: UIEdgeInsets = .init(top: 8, left: 16, bottom: 8, right: 16)
+    
+    convenience init(inset: UIEdgeInsets) {
+        self.init()
+        self.inset = inset
+    }
+    
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: inset))
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.height += inset.top + inset.bottom
+        contentSize.width += inset.left + inset.right
+        
+        return contentSize
+    }
+}

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewCard.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewCard.swift
@@ -1,0 +1,180 @@
+//
+//  ReviewCard.swift
+//  NEMO-fourcut-map-ios
+//
+//  Created by sanghyo on 2023/01/12.
+//
+
+import UIKit
+
+final class ReviewCard: UIView {
+    
+    private let container = UIView()
+    private let divider = UIView()
+    private let nameLabel = UILabel()
+    private let dateLabel = UILabel()
+    private let oneLineReviewLabel = UILabel()
+    private let oneLineReview = UILabel()
+    private let detailReview = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview()
+        setUpConstraints()
+        setUpUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+// Basic setup
+private extension ReviewCard {
+    
+    func addSubview() {
+        addSubview(container)
+        container.addSubviews(divider,
+                    nameLabel,
+                    dateLabel,
+                    oneLineReviewLabel,
+                    oneLineReview,
+                    detailReview)
+    }
+    
+    func setUpConstraints() {
+        setUpContainerConstraints()
+        setUpDividerConstraints()
+        setUpNameLabel()
+        setUpDateLabel()
+        setUpOneLineReviewLabel()
+        setUpOneLineReview()
+        setUpDetailReview()
+    }
+    
+    func setUpUI() {
+        setUpContainer()
+        setUpDivider()
+        setUpNameLabelConstraints()
+        setUpDateLabelConstraints()
+        setUpOneLineReviewLabelConstraints()
+        setUpOneLineReviewConstraints()
+        setUpDetailReviewConstraints()
+    }
+}
+
+// SetUp
+private extension ReviewCard {
+    
+    func setUpContainer() {
+        container.backgroundColor = .background
+    }
+    
+    func setUpDivider() {
+        divider.layer.borderWidth = 1
+        divider.layer.borderColor = UIColor.customGray?.cgColor
+    }
+    
+    func setUpNameLabel() {
+        nameLabel.text = "테스트"
+        nameLabel.font = UIFont.contentsDefaultAccent
+        nameLabel.textColor = .black
+    }
+    
+    func setUpDateLabel() {
+        dateLabel.text = "테스트 날짜"
+        dateLabel.font = UIFont.mini
+        dateLabel.textColor = .darkGray
+    }
+    
+    func setUpOneLineReviewLabel() {
+        oneLineReviewLabel.text = "한 줄 후기"
+        oneLineReviewLabel.font = UIFont.miniSemibold
+        oneLineReviewLabel.textColor = .darkGray
+    }
+    
+    func setUpOneLineReview() {
+        oneLineReview.text = "테스트용 글씨입니다. 테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다."
+        oneLineReview.font = UIFont.miniSemibold
+        oneLineReview.textColor = .customBlack
+        oneLineReview.lineBreakMode = .byCharWrapping
+        oneLineReview.numberOfLines = 0
+    }
+    
+    func setUpDetailReview() {
+        detailReview.numberOfLines = 0
+        detailReview.lineBreakMode = .byCharWrapping
+        detailReview.text = "테스트용 글씨입니다. 테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다. 테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다. 테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다.테스트용 글씨입니다."
+        detailReview.font = UIFont.mini
+        detailReview.textColor = .customBlack
+    }
+}
+
+// Constraints
+private extension ReviewCard {
+    
+    func setUpContainerConstraints() {
+        container.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func setUpDividerConstraints() {
+        divider.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.height.equalTo(1)
+            $0.leading.trailing.equalToSuperview()
+        }
+    }
+    
+    func setUpNameLabelConstraints() {
+        nameLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.top.equalTo(divider.snp.bottom).offset(17)
+        }
+    }
+    
+    func setUpDateLabelConstraints() {
+        dateLabel.snp.makeConstraints {
+            $0.centerY.equalTo(nameLabel.snp.centerY)
+            $0.trailing.equalToSuperview()
+        }
+    }
+    
+    func setUpOneLineReviewLabelConstraints() {
+        oneLineReviewLabel.snp.makeConstraints {
+            $0.top.equalTo(nameLabel.snp.bottom).offset(21)
+            $0.leading.equalToSuperview()
+        }
+    }
+    
+    func setUpOneLineReviewConstraints() {
+        oneLineReview.snp.makeConstraints {
+            $0.top.equalTo(oneLineReviewLabel.snp.top)
+            $0.leading.equalTo(oneLineReviewLabel.snp.trailing).offset(9)
+            $0.trailing.equalToSuperview()
+        }
+    }
+    
+    func setUpDetailReviewConstraints() {
+        detailReview.snp.makeConstraints {
+            $0.top.equalTo(oneLineReview.snp.bottom).offset(14)
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
+        }
+    }
+}
+
+#if DEBUG
+import SwiftUI
+struct ReviewCardPreview: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            ReviewCard()
+                .toPreview()
+                .frame(width: UIScreen.main.bounds.width - 32, height: 500)
+        }
+    }
+}
+#endif

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewProgressStack.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewProgressStack.swift
@@ -92,7 +92,7 @@ private extension ReviewProgressStack {
     }
     
     func setPercentageLabel(text: Float, textColor: UIColor?, textFont: UIFont?) {
-        percentageLabel.text = "\(Int(text) * 10)%"
+        percentageLabel.text = "\(Int(Float(text) * 10))%"
         percentageLabel.textColor = textColor
         percentageLabel.font = textFont
     }
@@ -103,16 +103,16 @@ import SwiftUI
 struct ReviewProgressStackPreview: PreviewProvider {
     static var previews: some View {
         VStack {
-            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .brandPink, textFont: UIFont.mini, tintColor: .brandPink, trackColor: .darkGray, scale: 1, percentage: 88)
+            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .brandPink, textFont: UIFont.mini, tintColor: .brandPink, trackColor: .darkGray, scale: 1, percentage: 8.8)
                 .toPreview()
                 .frame(width: UIScreen.main.bounds.width - 32, height: 25)
-            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .customMidBlack, textFont: UIFont.mini, tintColor: .customMidBlack, trackColor: .darkGray, scale: 1, percentage: 30)
+            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .customMidBlack, textFont: UIFont.mini, tintColor: .customMidBlack, trackColor: .darkGray, scale: 1, percentage: 3)
                 .toPreview()
                 .frame(width: UIScreen.main.bounds.width - 32, height: 25)
-            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .customBlack, textFont: UIFont.miniSemibold, tintColor: .darkGray, trackColor: .darkGray, scale: 0.5, percentage: 30)
+            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .customBlack, textFont: UIFont.miniSemibold, tintColor: .darkGray, trackColor: .darkGray, scale: 0.5, percentage: 3)
                 .toPreview()
                 .frame(width: UIScreen.main.bounds.width - 32, height: 25)
-            ReviewProgressStack("조명", feelingLabel: "만족스러워요", textColor: .customBlack, textFont: UIFont.miniSemibold, tintColor: .brandPink, trackColor: .darkGray, scale: 1, percentage: 30)
+            ReviewProgressStack("조명", feelingLabel: "만족스러워요", textColor: .customBlack, textFont: UIFont.miniSemibold, tintColor: .brandPink, trackColor: .darkGray, scale: 1, percentage: 3)
                 .toPreview()
                 .frame(width: UIScreen.main.bounds.width - 32, height: 25)
         }

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewProgressStack.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewProgressStack.swift
@@ -1,0 +1,22 @@
+//
+//  ReviewProgressStack.swift
+//  NEMO-fourcut-map-ios
+//
+//  Created by sanghyo on 2023/01/12.
+//
+
+import UIKit
+
+final class ReviewProgressStack: UIStackView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+
+}
+
+private extension ReviewProgressStack {
+    
+}
+

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewProgressStack.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewProgressStack.swift
@@ -28,7 +28,7 @@ final class ReviewProgressStack: UIStackView {
                      tintColor: UIColor?,
                      trackColor: UIColor?,
                      scale: CGFloat = 1,
-                     percentage: Float) {
+                     percentage: Float = 10) {
         self.init(frame: .zero)
         setPaddingLabel(category: category)
         addSubview()
@@ -44,7 +44,6 @@ final class ReviewProgressStack: UIStackView {
                         textColor: textColor,
                         textFont: textFont)
     }
-
 }
 
 private extension ReviewProgressStack {
@@ -71,7 +70,7 @@ private extension ReviewProgressStack {
             label.text = category
             label.font = UIFont.miniSemibold
             label.textColor = .brandPink
-            label.layer.cornerRadius = 10
+            label.layer.cornerRadius = 15
             label.layer.borderWidth = 1
             label.layer.borderColor = UIColor.brandPink?.cgColor
             label.layer.masksToBounds = true
@@ -88,12 +87,12 @@ private extension ReviewProgressStack {
     func setProgressView(tintColor: UIColor?, trackColor: UIColor?, percentage: Float, scale: CGFloat) {
         progressView.tintColor = tintColor
         progressView.trackTintColor = trackColor
-        progressView.progress = percentage / 100
+        progressView.progress = percentage
         progressView.transform = progressView.transform.scaledBy(x: 1, y: scale)
     }
     
     func setPercentageLabel(text: Float, textColor: UIColor?, textFont: UIFont?) {
-        percentageLabel.text = "\(Int(text))%"
+        percentageLabel.text = "\(Int(text) * 10)%"
         percentageLabel.textColor = textColor
         percentageLabel.font = textFont
     }

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewProgressStack.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/ReviewProgressStack.swift
@@ -8,15 +8,117 @@
 import UIKit
 
 final class ReviewProgressStack: UIStackView {
+
+    private let feelingLabel = UILabel()
+    private let progressView = UIProgressView(progressViewStyle: .default)
+    private let percentageLabel = UILabel()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
     
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    convenience init(_ category: String? = nil,
+                     feelingLabel: String,
+                     textColor: UIColor?,
+                     textFont: UIFont?,
+                     tintColor: UIColor?,
+                     trackColor: UIColor?,
+                     scale: CGFloat = 1,
+                     percentage: Float) {
+        self.init(frame: .zero)
+        setPaddingLabel(category: category)
+        addSubview()
+        setUpUI()
+        setFeelingLabel(text: feelingLabel,
+                        textColor: textColor,
+                        textFont: textFont)
+        setProgressView(tintColor: tintColor,
+                        trackColor: trackColor,
+                        percentage: percentage,
+                        scale: scale)
+        setPercentageLabel(text: percentage,
+                        textColor: textColor,
+                        textFont: textFont)
+    }
 
 }
 
 private extension ReviewProgressStack {
     
+    func addSubview() {
+        addArrangedSubview(feelingLabel)
+        addArrangedSubview(progressView)
+        addArrangedSubview(percentageLabel)
+    }
+    
+    func setUpUI() {
+        axis = .horizontal
+        spacing = 10
+        distribution = .fill
+        alignment = .center
+    }
 }
+
+private extension ReviewProgressStack {
+    
+    func setPaddingLabel(category: String?) {
+        if let category = category {
+            let label = PaddingLabel(inset: .init(top: 8, left: 16, bottom: 8, right: 16))
+            label.text = category
+            label.font = UIFont.miniSemibold
+            label.textColor = .brandPink
+            label.layer.cornerRadius = 10
+            label.layer.borderWidth = 1
+            label.layer.borderColor = UIColor.brandPink?.cgColor
+            label.layer.masksToBounds = true
+            addArrangedSubview(label)
+        }
+    }
+    
+    func setFeelingLabel(text: String, textColor: UIColor?, textFont: UIFont?) {
+        feelingLabel.text = text
+        feelingLabel.textColor = textColor
+        feelingLabel.font = textFont
+    }
+    
+    func setProgressView(tintColor: UIColor?, trackColor: UIColor?, percentage: Float, scale: CGFloat) {
+        progressView.tintColor = tintColor
+        progressView.trackTintColor = trackColor
+        progressView.progress = percentage / 100
+        progressView.transform = progressView.transform.scaledBy(x: 1, y: scale)
+    }
+    
+    func setPercentageLabel(text: Float, textColor: UIColor?, textFont: UIFont?) {
+        percentageLabel.text = "\(Int(text))%"
+        percentageLabel.textColor = textColor
+        percentageLabel.font = textFont
+    }
+}
+
+#if DEBUG
+import SwiftUI
+struct ReviewProgressStackPreview: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .brandPink, textFont: UIFont.mini, tintColor: .brandPink, trackColor: .darkGray, scale: 1, percentage: 88)
+                .toPreview()
+                .frame(width: UIScreen.main.bounds.width - 32, height: 25)
+            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .customMidBlack, textFont: UIFont.mini, tintColor: .customMidBlack, trackColor: .darkGray, scale: 1, percentage: 30)
+                .toPreview()
+                .frame(width: UIScreen.main.bounds.width - 32, height: 25)
+            ReviewProgressStack(feelingLabel: "만족스러워요", textColor: .customBlack, textFont: UIFont.miniSemibold, tintColor: .darkGray, trackColor: .darkGray, scale: 0.5, percentage: 30)
+                .toPreview()
+                .frame(width: UIScreen.main.bounds.width - 32, height: 25)
+            ReviewProgressStack("조명", feelingLabel: "만족스러워요", textColor: .customBlack, textFont: UIFont.miniSemibold, tintColor: .brandPink, trackColor: .darkGray, scale: 1, percentage: 30)
+                .toPreview()
+                .frame(width: UIScreen.main.bounds.width - 32, height: 25)
+        }
+    }
+}
+#endif
+
 

--- a/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/StoreDetailContentsStack.swift
+++ b/NEMO-fourcut-map-ios/Presenter/DetailStore/Views/StoreDetailContentsStack.swift
@@ -55,3 +55,16 @@ final class StoreDetailContentsStack: UIStackView {
         alignment = .center
     }
 }
+
+#if DEBUG
+import SwiftUI
+struct StoreDetailContentsStackPreview: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            StoreDetailContentsStack(labelText: "리모컨사용")
+                .toPreview()
+                .frame(width: UIScreen.main.bounds.width - 32, height: 200)
+        }
+    }
+}
+#endif

--- a/NEMO-fourcut-map-ios/Presenter/EditStore/Controllers/EditStoreViewController.swift
+++ b/NEMO-fourcut-map-ios/Presenter/EditStore/Controllers/EditStoreViewController.swift
@@ -1,0 +1,8 @@
+//
+//  EditStoreViewController.swift
+//  NEMO-fourcut-map-ios
+//
+//  Created by sanghyo on 2023/01/15.
+//
+
+import Foundation

--- a/NEMO-fourcut-map-ios/Presenter/EditStore/Views/SelectButtonStackView.swift
+++ b/NEMO-fourcut-map-ios/Presenter/EditStore/Views/SelectButtonStackView.swift
@@ -1,0 +1,12 @@
+//
+//  selectButtonStackView.swift
+//  NEMO-fourcut-map-ios
+//
+//  Created by sanghyo on 2023/01/15.
+//
+
+import UIKit
+
+final class SelectButtonStackView: UIStackView {
+    
+}

--- a/NEMO-fourcut-map-ios/Presenter/EditStore/Views/SelectMultipleButtonsStackView.swift
+++ b/NEMO-fourcut-map-ios/Presenter/EditStore/Views/SelectMultipleButtonsStackView.swift
@@ -1,0 +1,12 @@
+//
+//  SelectMultipleButtonsStackView.swift
+//  NEMO-fourcut-map-ios
+//
+//  Created by sanghyo on 2023/01/15.
+//
+
+import UIKit
+
+final class SelectMultipleButtonsStackView: UIStackView {
+    
+}


### PR DESCRIPTION
# 이슈 번호
🔒 Close #31 

## 구현 / 변경 사항 이유
상세정보 UI중 후기부분을 구현했습니다.
2차 sprint로 미뤘지만 간략하게나마 구현을 했습니다.
리뷰 요약부분의 progressView를 하나의 컴포넌트로 만들었습니다.
후기 tableView에 들어갈 cell의 UI를 일반 UIView로 구현했습니다. 추후에 cell로 변경이 필요합니다.
<img src="https://user-images.githubusercontent.com/26588989/215704031-660ec207-c5df-4499-b918-826e5a525d8c.jpg" width="300" /><img src="https://user-images.githubusercontent.com/26588989/215704078-60c47898-9676-46cf-ab0e-0a0c78a12201.jpg" width="300" />
<img src="https://user-images.githubusercontent.com/26588989/215704057-622e2859-96fc-44c4-ba49-836d985583ea.png" width="300" />

## 리뷰 포인트
scrollview를 programmatically 하게 작성하는데 애를 먹었습니다. 해당부분에 대한 심도있는 공부가 추후에 필요해보입니다.
리뷰 부분을 tableView로 구현하고, 리뷰 요약 부분을 table header로 넣어놓을 생각입니다.
추후에 개선이 필요합니다

## References


